### PR TITLE
reenabled linter, fed history dependency into useEffect on project filters

### DIFF
--- a/src/views/projectsView/ProjectFilters.jsx
+++ b/src/views/projectsView/ProjectFilters.jsx
@@ -65,10 +65,7 @@ export default function ProjectFilters(props) {
       pathname: history.location.pathname,
       search: formatSearchPath(currentFilters),
     });
-    // disabled linting because setting history as a dependencie results in infinte
-    // rendering. todo: help wanted
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentFilters]);
+  }, [currentFilters, history]);
 
   return (
     <Row className="text-center">


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/4805

This code looks great! I reenabled the linter for the useEffect on project filters and fed the history dependency into it.