### PR TITLE
Remove improperly labeled issue warning

### DIFF
--- a/src/shared/indexIssueDetails/Issues.jsx
+++ b/src/shared/indexIssueDetails/Issues.jsx
@@ -82,10 +82,8 @@ export default function Issues(props) {
     return <p>{context.error}</p>;
   } else if (!context.isLoaded && !context.error) {
     return <SpinnerWrapper />;
-  } else if (context.issues.length === 0) {
+  } else if (issues.length === 0) {
     return <p>No issues found.</p>;
-  } else if (!parentLabel) {
-    return <p> This index issue has been improperly labled :(</p>;
   }
 
   return (


### PR DESCRIPTION
Removes the warning from the issues listing when an index issue does not have a project or product label. I had implemented this to prompt ourselves to address these issues, but it's not appropriate now that we're sharing this site widely. If an index issue is missing a product or project issue, the message "No issues found." will be displayed.

<img width="805" alt="Screen Shot 2021-01-30 at 11 50 44 AM" src="https://user-images.githubusercontent.com/14793120/106364011-9ae0db80-62f1-11eb-80b0-a7f9b33f49b9.png">

