### PR TITLE
Increase issue query limit to 100k

### DIFF
--- a/components/shared/IndexIssueListItem.js
+++ b/components/shared/IndexIssueListItem.js
@@ -25,8 +25,7 @@ const markdownRenderers = {
   },
 };
 
-export default function IndexIsssueListItem(props) {
-  let { type, issue } = props;
+export default function IndexIsssueListItem({ type, issue }) {
   const [description, img] = parseBody(issue.body);
   return (
     <Link

--- a/components/wrappers/IssuesContextWrapper.js
+++ b/components/wrappers/IssuesContextWrapper.js
@@ -84,14 +84,13 @@ function handleData(data, setData) {
   setData(dataHandled.sort(sortByUpdatedDate));
 }
 
-export function IssuesContextWrapper(props) {
+export function IssuesContextWrapper({ url, children }) {
   const [data, setData] = React.useState([]);
   const [error, setError] = React.useState(null);
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [workgroups, setWorkgroups] = React.useState([]);
   const [projectIssues, setProjectIssues] = React.useState([]);
   const [productIssues, setProductIssues] = React.useState([]);
-  const { url, children } = props;
 
   React.useEffect(() => {
     fetch(url)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,7 +4,7 @@ import CustomHead from "./CustomHead";
 import "../styles/custom.scss";
 
 const ISSUES_ENDPOINT =
-  "https://data.austintexas.gov/resource/rzwg-fyv8.json?$limit=10000";
+  "https://data.austintexas.gov/resource/rzwg-fyv8.json?$limit=100000";
 
 const EVALUATIONS_ENDPOINT =
   "https://api.knack.com/v1/pages/scene_162/views/view_311/records";


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/9576

I noticed that the Socrata query which fetches issues was capped at 10k. This means that some product/project indexes might not be included on the website once we reach 10k total issues. Some naive person apparently thought that was future proof 🙈 

This increases that limit to 100k.

Btw, yes, you read that right: we're fetching all ~10k of our github issues from socrata when we render our website. We can do better. This approach probably makes more sense
- Fetch only project/product issues when the website loads (bringing them into global context)
- On load issue details, fetch issues related to that product or project


### Steps to test
Click around projects and products at the [deploy preview](https://deploy-preview-38--atd-product.netlify.app/) and make sure it looks good.
