### PR TITLE
Increase hyperlink accessibility

### DIFF
--- a/components/shared/indexIssueDetails/IndexIssueDetails.js
+++ b/components/shared/indexIssueDetails/IndexIssueDetails.js
@@ -22,7 +22,7 @@ const markdownComponents = {
     <Image {...props} className="img-fluid" alt="image from github"/>
   ),
   a: ({ node, ...props }) => (
-    <a {...props} className="markdown-link"/>
+    <a {...props} className="link"/>
   ),
 };
 

--- a/components/shared/indexIssueDetails/IndexIssueDetails.js
+++ b/components/shared/indexIssueDetails/IndexIssueDetails.js
@@ -19,7 +19,10 @@ const markdownComponents = {
   // This custom renderer changes how images are rendered
   // we use it to constrain the max width of an image to its container
   img: ({ node, ...props }) => (
-    <Image className="img-fluid" alt="image from github" {...props} />
+    <Image {...props} className="img-fluid" alt="image from github"/>
+  ),
+  a: ({ node, ...props }) => (
+    <a {...props} className="markdown-link"/>
   ),
 };
 

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -14,6 +14,10 @@ $nav-shadow: #d5d5d5;
   border-bottom: 1px dotted;
 }
 
+.markdown-link {
+  text-decoration: underline !important;
+}
+
 .status-filter-inactive {
   border-radius: 0px !important;
   border: none !important;

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -14,10 +14,6 @@ $nav-shadow: #d5d5d5;
   border-bottom: 1px dotted;
 }
 
-.markdown-link {
-  text-decoration: underline !important;
-}
-
 .status-filter-inactive {
   border-radius: 0px !important;
   border: none !important;


### PR DESCRIPTION
This PR closes: https://github.com/cityofaustin/atd-data-tech/issues/5530
This is the deploy preview: https://deploy-preview-70--atd-product.netlify.app/products/5150
Here are the details changed:
For `a` element:
- Remove text-decoration: none
- Swap in #1059AD* for color

From `.nav-link` class:
- Add text-decoration: none

The `.nav-link` class actually has always had `text-decoration: none` established, since there is a global link variable that enables `text-decoration: none`. Only removing it from `a` is needed.