### PR TITLE
Fix workgroup params navigation

### DIFF
--- a/components/projectsView/ProjectsList.js
+++ b/components/projectsView/ProjectsList.js
@@ -75,22 +75,27 @@ export default function ProjectsList(props) {
   const isLoaded = props.isLoaded;
   const { scores } = useContext(EvaluationsContext);
   const location = useRouter();
-  const [search] = useState(new URLSearchParams(location.query));
   const [currentFilters, setCurrentFilters] = useState({});
   const [showChartView, setShowChartView] = useState(false);
 
   useEffect(() => {
     /*
-    check current url for filter params after issues are loaded. set them if present, 
-    otherwise set default filter values
+    Check current url for filter params after issues are loaded. Set them if present, 
+    otherwise set default filter values.
+    Using the isReady field indicates when the query is fully updated after hydration.
+    Checking if the query is ready before using it makes sure 
+    we carry over the search params on a page refresh.
     */
-    let paramFilters = {};
-    FILTER_DEFS.forEach((filterDef) => {
-      const value = search.get(filterDef.key);
-      paramFilters[filterDef.key] = value ? value : filterDef.default;
-    });
-    setCurrentFilters(paramFilters);
-  }, [issues, search]);
+    if (location.isReady) {
+      const search = new URLSearchParams(location.query);
+      let paramFilters = {};
+      FILTER_DEFS.forEach((filterDef) => {
+        const value = search.get(filterDef.key);
+        paramFilters[filterDef.key] = value ? value : filterDef.default;
+      });
+      setCurrentFilters(paramFilters);
+    }
+  }, [issues, location.isReady]);
 
   const displayIssues = useDisplayIssues({ currentFilters, projectIssues });
 


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/13189

Docs on [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization#how-it-works) and this stack overflow [thread](https://stackoverflow.com/questions/69412453/next-js-router-query-getting-undefined-on-refreshing-page-but-works-if-you-navi) lead me to the `isReady` field on a router object which allows you to distinguish when the query is fully updated and ready for use.

I ended up not needing to address John's second idea in this [comment](https://github.com/cityofaustin/atd-data-tech/issues/13189#issuecomment-1662994847), simply fixing the routers search query being `undefined` seemed to do the trick.

## Testing

1. Go to https://deploy-preview-77--atd-product.netlify.app/projects?status=in_progress&workgroup=Finance
2. The URL should still have the Finance workgroup search param and only projects in the Finance workgroup should be displayed.
3. Test adding diff search parameters (status and workgroup) and refresh the page to make sure the search params you added stick around.