### PR TITLE
Add back the activity tab for projects

### DIFF
--- a/components/shared/indexIssueDetails/Comments.js
+++ b/components/shared/indexIssueDetails/Comments.js
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Card from "react-bootstrap/Card";
+import Image from "react-bootstrap/Image";
+import ReactMarkdown from "react-markdown";
+
+import SpinnerWrapper from "../../wrappers/SpinnerWrapper";
+
+const markdownComponents = {
+  // This custom renderer changes how images are rendered
+  // we use it to constrain the max width of an image to its container
+  img: ({ node, ...props }) => (
+    <Image className="img-fluid" alt="image from github" {...props} />
+  ),
+};
+
+function Comment({ comment }) {
+  const createdAt = new Date(comment.created_at).toLocaleDateString();
+  return (
+    <Card className="mt-2">
+      <Card.Header>
+        <b>{comment.user.login}</b>
+        <span className="text-muted ms-1">commented on {createdAt}</span>
+      </Card.Header>
+      <Card.Body className="py-1">
+        <Row className="mb-2 mt-0 pt-0">
+          <Col xs="auto" className="text-muted">
+            <i></i>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <ReactMarkdown skipHtml components={markdownComponents}>
+              {comment.body}
+            </ReactMarkdown>
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default function Comments({ issueNumber }) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const url = `https://api.github.com/repos/cityofaustin/atd-data-tech/issues/${issueNumber}/comments?per_page=100`;
+
+    fetch(url)
+      .then((res) => res.json())
+      .then(
+        (result) => {
+          setIsLoaded(true);
+          if (result.error) {
+            // on query error, socrata returns 200 with error message in body
+            setError(result.message.toString());
+          } else {
+            // note issue comments sort oldest to newest. no sort param avail in API
+            setData(result.reverse());
+          }
+        },
+        (error) => {
+          setIsLoaded(true);
+          setError(error.toString());
+        }
+      );
+  }, [issueNumber]);
+
+  if (error) {
+    return <p>{error}</p>;
+  } else if (!isLoaded && !error) {
+    return <SpinnerWrapper />;
+  } else if (!data || data.length === 0) {
+    return <p>No comments.</p>;
+  }
+
+  return (
+    <>
+      {data.map((comment) => (
+        <Comment key={comment.id} comment={comment} />
+      ))}
+    </>
+  );
+}

--- a/components/shared/indexIssueDetails/IndexIssueDetails.js
+++ b/components/shared/indexIssueDetails/IndexIssueDetails.js
@@ -10,6 +10,7 @@ import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
 import Image from "react-bootstrap/Image";
 
+import Comments from "./Comments";
 import ProjectEvaluation from "./ProjectEvaluation";
 import SpinnerWrapper from "../../wrappers/SpinnerWrapper";
 import Issues from "./Issues";
@@ -80,6 +81,11 @@ function IssueTabs({ indexType, issue }) {
       {indexType === "project" && (
         <Tab eventKey="evaluation" title="Evaluation">
           <ProjectEvaluation project={issue} />
+        </Tab>
+      )}
+      {indexType === "project" && (
+        <Tab eventKey="activity" title="Activity">
+          <Comments issueNumber={issue.number} />
         </Tab>
       )}
       <Tab eventKey="issues" title="Issues">


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/16836

The activity tab should be on the projects page, but not the product page:

A projects page: 
https://deploy-preview-90--atd-product.netlify.app/projects/4937?tab=activity

A product page:
https://deploy-preview-90--atd-product.netlify.app/products/5086
