### PR TITLE
Update Next.js configuration to prevent SSR

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
     locales: ["en"],
     defaultLocale: "en",
   },
+  output: "export",
   reactStrictMode: true,
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,4 @@
 const nextConfig = {
-  i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
-  },
   output: "export",
   reactStrictMode: true,
 };


### PR DESCRIPTION
addresses: https://github.com/cityofaustin/atd-data-tech/issues/24129

Total team effort on this one, updated the config to match 
https://github.com/cityofaustin/atd-data-and-performance/blob/production/next.config.js

I tried only adding the `output: "export"` configuration and leaving the i18n setting as is, but that errored. Here is a less than helpful doc page https://nextjs.org/docs/messages/export-no-i18n


###  Test deployment

https://deploy-preview-105--atd-product.netlify.app

I was thinking we can merge this once approvals come in and then watch the netlify dashboard for the next few days and see if our build minutes go down before declaring Mission Accomplished