### PR TITLE
Hide the "loading..." text on the spinner 

### DIFF
--- a/components/wrappers/SpinnerWrapper.js
+++ b/components/wrappers/SpinnerWrapper.js
@@ -11,7 +11,7 @@ export default function SpinnerWrapper(props) {
         role="status"
         aria-hidden="true"
       />
-      <span className="sr-only">Loading...</span>
+      <span className="visually-hidden">Loading...</span>
     </>
   );
 }


### PR DESCRIPTION
Fixes:

* https://github.com/cityofaustin/atd-data-tech/issues/24785

Somewhere along the way, our loading spinner text regressed due to Bootstrap changing the appropriate classname for hidden, screen-reader-only content. This was causing our spinner to look like this 👇 

<img width="819" height="387" alt="Screenshot 2025-09-22 at 9 22 58 PM" src="https://github.com/user-attachments/assets/69eaaaaf-bb59-46b8-926a-176a2ba77a77" />

Instead of this this 👇 

<img width="803" height="303" alt="Screenshot 2025-09-22 at 9 25 58 PM" src="https://github.com/user-attachments/assets/dbb810d5-201a-44a2-8364-08666ffec40d" />


### Testing

To test, visit the [projects list](https://deploy-preview-110--atd-product.netlify.app/projects) and [products list](https://deploy-preview-110--atd-product.netlify.app/products) in the deploy preview, Then open your browser console, throttle the network down to 4g, and refresh.