### PR TITLE
Trim issue body to make sure the description snippet is captured correctly

### DIFF
--- a/components/utils.js
+++ b/components/utils.js
@@ -76,6 +76,8 @@ export function handleIssueData(data) {
     newIssue.body = newIssue.body || "";
     // remove html comments, which contain content we don't want to share
     newIssue.body = newIssue.body?.replace(/(<!-- .+? -->)/g, "");
+    // finally, remove leading/trailing whitespace
+    newIssue.body = newIssue.body.trim();
     newIssue.labels = newIssue.labels ? newIssue.labels.split(", ") : [];
     newIssue.workgroups = newIssue.workgroups
       ? newIssue.workgroups.split(", ")


### PR DESCRIPTION
## Associated issue

* https://github.com/cityofaustin/atd-data-tech/issues/24925

## Testing

Visit the [projects list in the deploy preview](https://deploy-preview-112--atd-product.netlify.app/) and notice that the **Finance & Purchasing Portal Redesign** card and the **Digital Award & Recognition Program** card have their descriptions populated. Compare to the [prod projects listing](https://austinmobility.io/projects?status=in_progress) to see the bug.

Note that the **City Brand Application** has an empty description on the ODP. We need to run the publishing ETL again to (hopefully) fix that one. UPDATE: Chia did that and the issue is fixed ✅ 

<img width="1245" height="804" alt="Screenshot 2025-10-02 at 12 19 53 PM" src="https://github.com/user-attachments/assets/b35386e2-5b95-486b-9a91-f16d041f2239" />
